### PR TITLE
fix: invalidate QML cache on plasmoid update

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Or visit [store.kde.org/p/1202579](https://store.kde.org/p/1202579).
 ### From .plasmoid file
 
 ```bash
-kpackagetool6 -t Plasma/Applet -i com.comexpertise.plasma.kdeconnectsms-2.0.0.plasmoid
+kpackagetool6 -t Plasma/Applet -i com.comexpertise.plasma.kdeconnectsms-<version>.plasmoid
 ```
 
 ### From source
@@ -58,6 +58,16 @@ kpackagetool6 -t Plasma/Applet -i .
 ```
 
 Then right-click your panel → **Add Widgets** → search **"KDE Connect SMS"**.
+
+### After updating
+
+If the widget still shows the old UI after an update, restart Plasma shell:
+
+```bash
+systemctl --user restart plasma-plasmashell.service
+```
+
+Or log out and log back in.
 
 ## Building
 

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
                 "Name": "David DIVERRES"
             }
         ],
-        "Version": "2.1.0",
+        "Version": "2.1.1",
         "Category": "Utilities",
         "Description": "Send SMS from your desktop via KDE Connect",
         "Icon": "kdeconnect",

--- a/scripts/build-plasmoid.sh
+++ b/scripts/build-plasmoid.sh
@@ -30,6 +30,12 @@ if [ -x "$PROJECT_DIR/translate/build.sh" ] && ls "$PROJECT_DIR"/translate/*.po 
     bash "$PROJECT_DIR/translate/build.sh"
 fi
 
+# Touch QML/JS files so zip timestamps are fresh — forces Qt QML cache
+# invalidation when kpackage extracts the archive (avoids stale UI after update)
+find "$PROJECT_DIR/contents" "$PROJECT_DIR/metadata.json" -type f \
+    \( -name "*.qml" -o -name "*.js" -o -name "metadata.json" \) \
+    -exec touch {} +
+
 # Remove previous build if present
 rm -f "$ARCHIVE_PATH"
 


### PR DESCRIPTION
## Summary

- Touch QML/JS files at build time so zip timestamps are fresh — forces Qt QML disk cache invalidation when kpackage extracts the archive (avoids stale UI after update)
- Add post-update restart instructions to README (`systemctl --user restart plasma-plasmashell.service`)
- Use `<version>` placeholder in README install command

## Context

After updating the plasmoid via KDE Store, Qt's QML disk cache could serve the old compiled bytecode because zip extraction preserved original file timestamps. Users had to log out/in to see the new UI.

## Test plan

- [ ] Build plasmoid with `bash scripts/build-plasmoid.sh`
- [ ] Verify QML files inside the zip have fresh timestamps (`unzip -l *.plasmoid`)
- [ ] Install over an existing version and confirm new UI appears without restart