### PR TITLE
Release v2.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ CLAUDE.md
 AGENTS.md
 .claude/
 .serena/
+screenshots/
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Or visit [store.kde.org/p/1202579](https://store.kde.org/p/1202579).
 ### From .plasmoid file
 
 ```bash
-kpackagetool6 -t Plasma/Applet -i com.comexpertise.plasma.kdeconnectsms-2.0.0.plasmoid
+kpackagetool6 -t Plasma/Applet -i com.comexpertise.plasma.kdeconnectsms-<version>.plasmoid
 ```
 
 ### From source
@@ -58,6 +58,16 @@ kpackagetool6 -t Plasma/Applet -i .
 ```
 
 Then right-click your panel → **Add Widgets** → search **"KDE Connect SMS"**.
+
+### After updating
+
+If the widget still shows the old UI after an update, restart Plasma shell:
+
+```bash
+systemctl --user restart plasma-plasmashell.service
+```
+
+Or log out and log back in.
 
 ## Building
 

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -26,5 +26,9 @@
     <entry name="speakerBeepReps" type="Int">
       <default>1</default>
     </entry>
+    <!-- Hide widget from panel (show only in edit mode) -->
+    <entry name="hideWidget" type="Bool">
+      <default>false</default>
+    </entry>
   </group>
 </kcfg>

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -8,6 +8,7 @@ import QtQuick.Layouts
 import QtQuick.Controls as Controls
 import org.kde.kirigami as Kirigami
 
+import org.kde.plasma.plasmoid
 import org.kde.kdeconnect as KDEConnect
 
 import "../code/helpers.js" as Helpers
@@ -20,6 +21,7 @@ Kirigami.FormLayout {
     property string cfg_defaultCountry
     property alias cfg_speakerBeep: speakerBeepCheck.checked
     property alias cfg_speakerBeepReps: speakerBeepReps.value
+    property alias cfg_hideWidget: hideWidgetCheck.checked
 
     // ── Device list (KDE Connect native model) ──
 
@@ -210,5 +212,60 @@ Kirigami.FormLayout {
         from: 1
         to: 10
         enabled: speakerBeepCheck.checked
+    }
+
+    // ── Widget visibility ──
+
+    Kirigami.Separator {
+        Kirigami.FormData.isSection: true
+    }
+
+    Controls.Label {
+        text: i18n("Widget visibility")
+        font.bold: true
+    }
+
+    Controls.CheckBox {
+        id: hideWidgetCheck
+        text: i18n("Hide widget icon from panel")
+        checked: plasmoid.configuration.hideWidget
+        onToggled: {
+            plasmoid.configuration.hideWidget = checked;
+            plasmoid.configuration.writeConfig();
+        }
+
+        Connections {
+            target: plasmoid.configuration
+            function onHideWidgetChanged() {
+                hideWidgetCheck.checked = plasmoid.configuration.hideWidget;
+            }
+        }
+    }
+
+    Controls.Label {
+        Layout.fillWidth: true
+        wrapMode: Text.Wrap
+        font.pixelSize: Kirigami.Theme.smallFont.pixelSize
+        color: plasmoid.configuration.hideWidget
+            ? Kirigami.Theme.neutralTextColor
+            : Kirigami.Theme.disabledTextColor
+        text: plasmoid.configuration.hideWidget
+            ? i18n("The widget icon is hidden from the panel. To restore it, enter Edit Mode, right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can also assign a global keyboard shortcut to toggle the popup.")
+            : i18n("Hides the widget icon from the panel. The widget remains accessible via Edit Mode or a keyboard shortcut.")
+    }
+
+    Controls.Button {
+        icon.name: "preferences-desktop-keyboard"
+        text: i18n("Configure Keyboard Shortcut…")
+        onClicked: Plasmoid.internalAction("configure").trigger()
+        Layout.topMargin: Kirigami.Units.smallSpacing
+    }
+
+    Controls.Label {
+        Layout.fillWidth: true
+        wrapMode: Text.Wrap
+        font.pixelSize: Kirigami.Theme.smallFont.pixelSize
+        color: Kirigami.Theme.disabledTextColor
+        text: i18n("Assign a global shortcut to open the widget popup without a panel icon.")
     }
 }

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -148,7 +148,11 @@ PlasmoidItem {
         }
     }
 
-    Component.onCompleted: _autoSelectDevice()
+    Component.onCompleted: {
+        _autoSelectDevice();
+        updatePlasmoidStatus();
+        hideWidgetAction.checked = plasmoid.configuration.hideWidget;
+    }
 
 
     // ── Compact representation ──
@@ -960,6 +964,44 @@ PlasmoidItem {
             root.fileShareError = "";
         }
     }
+
+    // ── Hide widget from panel ──
+
+    property bool editMode: {
+        if (Plasmoid.containment && Plasmoid.containment.corona) {
+            return Plasmoid.containment.corona.editMode;
+        }
+        return false;
+    }
+    property bool hideWidget: plasmoid.configuration.hideWidget
+
+    function updatePlasmoidStatus() {
+        Plasmoid.status = (editMode || !hideWidget)
+            ? PlasmaCore.Types.ActiveStatus
+            : PlasmaCore.Types.HiddenStatus;
+    }
+
+    onEditModeChanged: updatePlasmoidStatus()
+    onHideWidgetChanged: updatePlasmoidStatus()
+
+    property PlasmaCore.Action hideWidgetAction: PlasmaCore.Action {
+        text: i18n("Hide widget from panel")
+        icon.name: "visibility-symbolic"
+        checkable: true
+        onTriggered: {
+            plasmoid.configuration.hideWidget = !plasmoid.configuration.hideWidget;
+            plasmoid.configuration.writeConfig();
+        }
+    }
+
+    Connections {
+        target: plasmoid.configuration
+        function onHideWidgetChanged() {
+            hideWidgetAction.checked = plasmoid.configuration.hideWidget;
+        }
+    }
+
+    Plasmoid.contextualActions: [hideWidgetAction]
 
     Connections {
         target: beepExecutor

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
                 "Name": "David DIVERRES"
             }
         ],
-        "Version": "2.1.0",
+        "Version": "2.1.1",
         "Category": "Utilities",
         "Description": "Send SMS from your desktop via KDE Connect",
         "Icon": "kdeconnect",

--- a/scripts/build-plasmoid.sh
+++ b/scripts/build-plasmoid.sh
@@ -30,6 +30,12 @@ if [ -x "$PROJECT_DIR/translate/build.sh" ] && ls "$PROJECT_DIR"/translate/*.po 
     bash "$PROJECT_DIR/translate/build.sh"
 fi
 
+# Touch QML/JS files so zip timestamps are fresh — forces Qt QML cache
+# invalidation when kpackage extracts the archive (avoids stale UI after update)
+find "$PROJECT_DIR/contents" "$PROJECT_DIR/metadata.json" -type f \
+    \( -name "*.qml" -o -name "*.js" -o -name "metadata.json" \) \
+    -exec touch {} +
+
 # Remove previous build if present
 rm -f "$ARCHIVE_PATH"
 

--- a/translate/ar.po
+++ b/translate/ar.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Arabic <ar@li.org>\n"
@@ -199,6 +199,40 @@ msgstr "تشغيل صوت تنبيه بعد إرسال الرسالة القصي
 msgid "Beep repetitions:"
 msgstr "عدد تكرارات التنبيه:"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "إظهار الودجة"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "إخفاء أيقونة الودجة من اللوحة"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"أيقونة الودجة مخفية من اللوحة. لاستعادتها، ادخل وضع التحرير، وانقر بزر "
+"الماوس الأيمن على الودجة، وألغِ تحديد \"إخفاء الودجة من اللوحة\". تلميح: "
+"يمكنك أيضًا تعيين اختصار لوحة مفاتيح عام لفتح النافذة المنبثقة."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"يخفي أيقونة الودجة من اللوحة. تظل الودجة قابلة للوصول عبر وضع التحرير أو "
+"اختصار لوحة المفاتيح."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "تكوين اختصار لوحة المفاتيح…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr "تعيين اختصار عام لفتح النافذة المنبثقة للودجة بدون أيقونة في اللوحة."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "مزامنة جهات الاتصال من الهاتف"
@@ -310,3 +344,7 @@ msgstr "الرد على %1…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "إرسال"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "إخفاء الودجة من اللوحة"

--- a/translate/cs.po
+++ b/translate/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Czech <cs@li.org>\n"
@@ -183,6 +183,43 @@ msgstr "Přehrát zvukový signál po odeslání SMS"
 msgid "Beep repetitions:"
 msgstr "Počet opakování signálu:"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "Viditelnost widgetu"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "Skrýt ikonu widgetu z panelu"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"Ikona widgetu je skryta z panelu. Pro obnovení přejděte do režimu úprav, "
+"klikněte pravým tlačítkem na widget a zrušte zaškrtnutí „Skrýt widget z "
+"panelu\". Tip: můžete také přiřadit globální klávesovou zkratku pro otevření "
+"vyskakovacího okna."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"Skryje ikonu widgetu z panelu. Widget zůstává přístupný přes režim úprav "
+"nebo klávesovou zkratku."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "Nastavit klávesovou zkratku…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+"Přiřadit globální zkratku pro otevření vyskakovacího okna widgetu bez ikony "
+"na panelu."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "Synchronizovat kontakty z telefonu"
@@ -296,3 +333,7 @@ msgstr "Odpovědět %1…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "Odeslat"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "Skrýt widget z panelu"

--- a/translate/de.po
+++ b/translate/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: German <de@li.org>\n"
@@ -178,6 +178,44 @@ msgstr "Signalton nach dem Senden der SMS abspielen"
 msgid "Beep repetitions:"
 msgstr "Signalton-Wiederholungen:"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "Widget-Sichtbarkeit"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "Widget-Symbol aus der Leiste ausblenden"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"Das Widget-Symbol ist in der Leiste ausgeblendet. Um es wiederherzustellen, "
+"wechseln Sie in den Bearbeitungsmodus, klicken Sie mit der rechten Maustaste "
+"auf das Widget und deaktivieren Sie „Widget aus der Leiste ausblenden\". "
+"Tipp: Sie können auch ein globales Tastenkürzel zuweisen, um das Popup "
+"umzuschalten."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"Blendet das Widget-Symbol aus der Leiste aus. Das Widget bleibt über den "
+"Bearbeitungsmodus oder ein Tastenkürzel erreichbar."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "Tastenkürzel einrichten…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+"Ein globales Tastenkürzel zuweisen, um das Widget-Popup ohne Leistensymbol "
+"zu öffnen."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "Kontakte vom Telefon synchronisieren"
@@ -292,3 +330,7 @@ msgstr "Antwort an %1…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "Senden"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "Widget aus der Leiste ausblenden"

--- a/translate/es.po
+++ b/translate/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -178,6 +178,43 @@ msgstr "Reproducir un pitido después de enviar el SMS"
 msgid "Beep repetitions:"
 msgstr "Repeticiones del pitido:"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "Visibilidad del widget"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "Ocultar icono del widget del panel"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"El icono del widget está oculto del panel. Para restaurarlo, entre en el "
+"modo de edición, haga clic derecho en el widget y desmarque «Ocultar widget "
+"del panel». Consejo: también puede asignar un atajo de teclado global para "
+"abrir la ventana emergente."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"Oculta el icono del widget del panel. El widget sigue accesible mediante el "
+"modo de edición o un atajo de teclado."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "Configurar atajo de teclado…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+"Asignar un atajo global para abrir la ventana emergente del widget sin icono "
+"en el panel."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "Sincronizar contactos desde el teléfono"
@@ -293,3 +330,7 @@ msgstr "Responder a %1…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "Enviar"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "Ocultar widget del panel"

--- a/translate/fr.po
+++ b/translate/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -178,6 +178,43 @@ msgstr "Jouer un bip sonore après l'envoi du SMS"
 msgid "Beep repetitions:"
 msgstr "Nombre de bips :"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "Visibilité du widget"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "Masquer l'icône du widget du panneau"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"L'icône du widget est masquée du panneau. Pour la restaurer, passez en mode "
+"Édition, faites un clic droit sur le widget et décochez « Masquer le widget "
+"du panneau ». Astuce : vous pouvez aussi assigner un raccourci clavier "
+"global pour ouvrir la fenêtre contextuelle."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"Masque l'icône du widget du panneau. Le widget reste accessible via le mode "
+"Édition ou un raccourci clavier."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "Configurer le raccourci clavier…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+"Assigner un raccourci global pour ouvrir la fenêtre contextuelle du widget "
+"sans icône dans le panneau."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "Synchroniser les contacts depuis le téléphone"
@@ -294,3 +331,7 @@ msgstr "Répondre à %1…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "Envoyer"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "Masquer le widget du panneau"

--- a/translate/it.po
+++ b/translate/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -178,6 +178,43 @@ msgstr "Riprodurre un segnale acustico dopo l'invio dell'SMS"
 msgid "Beep repetitions:"
 msgstr "Ripetizioni del segnale:"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "Visibilità del widget"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "Nascondi l'icona del widget dal pannello"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"L'icona del widget è nascosta dal pannello. Per ripristinarla, entra in "
+"modalità modifica, fai clic destro sul widget e deseleziona \"Nascondi "
+"widget dal pannello\". Suggerimento: puoi anche assegnare una scorciatoia da "
+"tastiera globale per aprire il popup."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"Nasconde l'icona del widget dal pannello. Il widget resta accessibile "
+"tramite la modalità modifica o una scorciatoia da tastiera."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "Configura scorciatoia da tastiera…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+"Assegna una scorciatoia globale per aprire il popup del widget senza icona "
+"nel pannello."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "Sincronizza contatti dal telefono"
@@ -293,3 +330,7 @@ msgstr "Rispondi a %1…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "Invia"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "Nascondi widget dal pannello"

--- a/translate/ja.po
+++ b/translate/ja.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Japanese <ja@li.org>\n"
@@ -173,6 +173,43 @@ msgstr "SMS送信後にビープ音を再生"
 msgid "Beep repetitions:"
 msgstr "ビープ音の繰り返し回数："
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "ウィジェットの表示"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "パネルからウィジェットアイコンを非表示にする"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"ウィジェットアイコンはパネルから非表示になっています。復元するには、編集モー"
+"ドに入り、ウィジェットを右クリックして「パネルからウィジェットを非表示」の"
+"チェックを外してください。ヒント：グローバルキーボードショートカットを割り当"
+"ててポップアップを切り替えることもできます。"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"パネルからウィジェットアイコンを非表示にします。ウィジェットは編集モードまた"
+"はキーボードショートカットからアクセスできます。"
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "キーボードショートカットの設定…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+"パネルアイコンなしでウィジェットのポップアップを開くグローバルショートカット"
+"を割り当てます。"
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "スマートフォンから連絡先を同期"
@@ -287,3 +324,7 @@ msgstr "%1 に返信…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "送信"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "パネルからウィジェットを非表示"

--- a/translate/ko.po
+++ b/translate/ko.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Korean <ko@li.org>\n"
@@ -173,6 +173,40 @@ msgstr "SMS 전송 후 알림음 재생"
 msgid "Beep repetitions:"
 msgstr "알림음 반복 횟수:"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "위젯 표시"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "패널에서 위젯 아이콘 숨기기"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"위젯 아이콘이 패널에서 숨겨져 있습니다. 복원하려면 편집 모드로 전환하고 위젯"
+"을 마우스 오른쪽 버튼으로 클릭한 후 \"패널에서 위젯 숨기기\"를 해제하세요. "
+"팁: 전역 키보드 단축키를 지정하여 팝업을 전환할 수도 있습니다."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"패널에서 위젯 아이콘을 숨깁니다. 위젯은 편집 모드 또는 키보드 단축키를 통해 "
+"계속 접근할 수 있습니다."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "키보드 단축키 설정…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr "패널 아이콘 없이 위젯 팝업을 열 수 있는 전역 단축키를 지정합니다."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "휴대전화에서 연락처 동기화"
@@ -284,3 +318,7 @@ msgstr "%1에 답장…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "보내기"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "패널에서 위젯 숨기기"

--- a/translate/nl.po
+++ b/translate/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -178,6 +178,43 @@ msgstr "Pieptoon afspelen na het verzenden van het SMS-bericht"
 msgid "Beep repetitions:"
 msgstr "Pieptoon herhalingen:"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "Widgetzichtbaarheid"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "Widgetpictogram verbergen in paneel"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"Het widgetpictogram is verborgen in het paneel. Om het te herstellen, ga "
+"naar de bewerkingsmodus, klik met de rechtermuisknop op de widget en schakel "
+"\"Widget verbergen in paneel\" uit. Tip: u kunt ook een globale sneltoets "
+"toewijzen om het popup-venster te openen."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"Verbergt het widgetpictogram in het paneel. De widget blijft toegankelijk "
+"via de bewerkingsmodus of een sneltoets."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "Sneltoets instellen…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+"Een globale sneltoets toewijzen om het widgetpopup-venster te openen zonder "
+"paneelpictogram."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "Contacten synchroniseren vanaf telefoon"
@@ -293,3 +330,7 @@ msgstr "Antwoord aan %1…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "Verzenden"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "Widget verbergen in paneel"

--- a/translate/pl.po
+++ b/translate/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -184,6 +184,43 @@ msgstr "Odtwórz sygnał dźwiękowy po wysłaniu SMS-a"
 msgid "Beep repetitions:"
 msgstr "Powtórzenia sygnału:"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "Widoczność widżetu"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "Ukryj ikonę widżetu z panelu"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"Ikona widżetu jest ukryta na panelu. Aby ją przywrócić, wejdź w tryb edycji, "
+"kliknij prawym przyciskiem myszy widżet i odznacz „Ukryj widżet z panelu\". "
+"Wskazówka: możesz także przypisać globalny skrót klawiaturowy, aby "
+"przełączać okno wyskakujące."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"Ukrywa ikonę widżetu z panelu. Widżet pozostaje dostępny przez tryb edycji "
+"lub skrót klawiaturowy."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "Skonfiguruj skrót klawiaturowy…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+"Przypisz globalny skrót, aby otwierać okno wyskakujące widżetu bez ikony na "
+"panelu."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "Synchronizuj kontakty z telefonu"
@@ -295,3 +332,7 @@ msgstr "Odpowiedz na %1…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "Wyślij"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "Ukryj widżet z panelu"

--- a/translate/pt_BR.po
+++ b/translate/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -178,6 +178,42 @@ msgstr "Reproduzir um bip após o envio do SMS"
 msgid "Beep repetitions:"
 msgstr "Repetições do bip:"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "Visibilidade do widget"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "Ocultar ícone do widget do painel"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"O ícone do widget está oculto do painel. Para restaurá-lo, entre no modo de "
+"edição, clique com o botão direito no widget e desmarque \"Ocultar widget do "
+"painel\". Dica: você também pode atribuir um atalho de teclado global para "
+"abrir o popup."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"Oculta o ícone do widget do painel. O widget permanece acessível pelo modo "
+"de edição ou por um atalho de teclado."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "Configurar atalho de teclado…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+"Atribuir um atalho global para abrir o popup do widget sem ícone no painel."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "Sincronizar contatos do telefone"
@@ -293,3 +329,7 @@ msgstr "Responder a %1…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "Enviar"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "Ocultar widget do painel"

--- a/translate/ru.po
+++ b/translate/ru.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -184,6 +184,43 @@ msgstr "Воспроизводить звуковой сигнал после о
 msgid "Beep repetitions:"
 msgstr "Количество сигналов:"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "Видимость виджета"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "Скрыть значок виджета с панели"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"Значок виджета скрыт с панели. Чтобы восстановить его, войдите в режим "
+"редактирования, щёлкните правой кнопкой мыши по виджету и снимите флажок "
+"«Скрыть виджет с панели». Совет: вы также можете назначить глобальную "
+"комбинацию клавиш для открытия всплывающего окна."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"Скрывает значок виджета с панели. Виджет остаётся доступным через режим "
+"редактирования или комбинацию клавиш."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "Настроить комбинацию клавиш…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+"Назначить глобальную комбинацию клавиш для открытия всплывающего окна "
+"виджета без значка на панели."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "Синхронизировать контакты с телефона"
@@ -296,3 +333,7 @@ msgstr "Ответить %1…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "Отправить"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "Скрыть виджет с панели"

--- a/translate/template.pot
+++ b/translate/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -180,6 +180,30 @@ msgstr ""
 msgid "Beep repetitions:"
 msgstr ""
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr ""
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr ""
+
+#: contents/ui/configGeneral.qml
+msgid "The widget icon is hidden from the panel. To restore it, enter Edit Mode, right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+
+#: contents/ui/configGeneral.qml
+msgid "Hides the widget icon from the panel. The widget remains accessible via Edit Mode or a keyboard shortcut."
+msgstr ""
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr ""
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr ""
@@ -286,4 +310,8 @@ msgstr ""
 
 #: contents/ui/main.qml
 msgid "Send"
+msgstr ""
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
 msgstr ""

--- a/translate/tr.po
+++ b/translate/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Turkish <tr@li.org>\n"
@@ -178,6 +178,43 @@ msgstr "SMS gönderildikten sonra bip sesi çal"
 msgid "Beep repetitions:"
 msgstr "Bip sesi tekrarı:"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "Widget görünürlüğü"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "Widget simgesini panelden gizle"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"Widget simgesi panelden gizlenmiştir. Geri yüklemek için Düzenleme Moduna "
+"girin, widget'a sağ tıklayın ve \"Widget'ı panelden gizle\" seçeneğinin "
+"işaretini kaldırın. İpucu: Açılır pencereyi açmak için bir genel klavye "
+"kısayolu da atayabilirsiniz."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"Widget simgesini panelden gizler. Widget, Düzenleme Modu veya klavye "
+"kısayolu aracılığıyla erişilebilir kalır."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "Klavye kısayolunu yapılandır…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+"Panel simgesi olmadan widget açılır penceresini açmak için genel bir kısayol "
+"atayın."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "Kişileri telefondan eşitle"
@@ -291,3 +328,7 @@ msgstr "%1 için yanıt yazın…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "Gönder"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "Widget'ı panelden gizle"

--- a/translate/uk.po
+++ b/translate/uk.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Ukrainian <uk@li.org>\n"
@@ -184,6 +184,43 @@ msgstr "Відтворити звуковий сигнал після надси
 msgid "Beep repetitions:"
 msgstr "Кількість сигналів:"
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "Видимість віджета"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "Сховати значок віджета з панелі"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"Значок віджета сховано з панелі. Щоб відновити його, увійдіть у режим "
+"редагування, клацніть правою кнопкою миші на віджеті та зніміть прапорець "
+"«Сховати віджет з панелі». Порада: ви також можете призначити глобальну "
+"комбінацію клавіш для відкриття спливаючого вікна."
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr ""
+"Ховає значок віджета з панелі. Віджет залишається доступним через режим "
+"редагування або комбінацію клавіш."
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "Налаштувати комбінацію клавіш…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr ""
+"Призначити глобальну комбінацію клавіш для відкриття спливаючого вікна "
+"віджета без значка на панелі."
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "Синхронізувати контакти з телефону"
@@ -297,3 +334,7 @@ msgstr "Відповісти %1…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "Надіслати"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "Сховати віджет з панелі"

--- a/translate/zh_CN.po
+++ b/translate/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kdeconnectsms\n"
 "Report-Msgid-Bugs-To: https://www.comexpertise.com\n"
-"POT-Creation-Date: 2026-03-13 20:01+0100\n"
+"POT-Creation-Date: 2026-03-16 03:24+0100\n"
 "PO-Revision-Date: 2026-03-11 00:24+0000\n"
 "Last-Translator: David DIVERRES <david@comexpertise.com>\n"
 "Language-Team: Chinese (Simplified) <zh_CN@li.org>\n"
@@ -173,6 +173,37 @@ msgstr "短信发送后播放提示音"
 msgid "Beep repetitions:"
 msgstr "提示音重复次数："
 
+#: contents/ui/configGeneral.qml
+msgid "Widget visibility"
+msgstr "小部件可见性"
+
+#: contents/ui/configGeneral.qml
+msgid "Hide widget icon from panel"
+msgstr "从面板隐藏小部件图标"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"The widget icon is hidden from the panel. To restore it, enter Edit Mode, "
+"right-click the widget, and uncheck \"Hide widget from panel\". Tip: you can "
+"also assign a global keyboard shortcut to toggle the popup."
+msgstr ""
+"小部件图标已从面板隐藏。要恢复它，请进入编辑模式，右键点击小部件，然后取消勾"
+"选「从面板隐藏小部件」。提示：您还可以分配一个全局键盘快捷键来切换弹出窗口。"
+
+#: contents/ui/configGeneral.qml
+msgid ""
+"Hides the widget icon from the panel. The widget remains accessible via Edit "
+"Mode or a keyboard shortcut."
+msgstr "从面板隐藏小部件图标。小部件仍可通过编辑模式或键盘快捷键访问。"
+
+#: contents/ui/configGeneral.qml
+msgid "Configure Keyboard Shortcut…"
+msgstr "配置键盘快捷键…"
+
+#: contents/ui/configGeneral.qml
+msgid "Assign a global shortcut to open the widget popup without a panel icon."
+msgstr "分配一个全局快捷键，无需面板图标即可打开小部件弹出窗口。"
+
 #: contents/ui/main.qml
 msgid "Sync contacts from phone"
 msgstr "从手机同步联系人"
@@ -284,3 +315,7 @@ msgstr "回复 %1…"
 #: contents/ui/main.qml
 msgid "Send"
 msgstr "发送"
+
+#: contents/ui/main.qml
+msgid "Hide widget from panel"
+msgstr "从面板隐藏小部件"


### PR DESCRIPTION
## Summary

- Add option to hide the widget from the panel (show only on desktop)
- Fix Plasma cache invalidation on update (touch QML files at build time)
- Add post-update restart instructions to README
- Add screenshots directory to .gitignore

## Translations

All 15 locales updated for the new "hide from panel" setting strings.